### PR TITLE
fix startup on pthreads

### DIFF
--- a/src/mono/wasm/runtime/dotnet.d.ts
+++ b/src/mono/wasm/runtime/dotnet.d.ts
@@ -50,7 +50,7 @@ declare interface EmscriptenModule {
     stackRestore(stack: VoidPtr): void;
     stackAlloc(size: number): VoidPtr;
     ready: Promise<unknown>;
-    instantiateWasm?: (imports: WebAssembly.Imports, successCallback: (instance: WebAssembly.Instance) => void) => any;
+    instantiateWasm?: (imports: WebAssembly.Imports, successCallback: (instance: WebAssembly.Instance, module: WebAssembly.Module) => void) => any;
     preInit?: (() => any)[];
     preRun?: (() => any)[];
     onRuntimeInitialized?: () => any;


### PR DESCRIPTION
Emscripten doesn't run preRun, onRuntimeInitialized or postRun on
pthread workers.  it sets insantiateWasm to a custom callback that
receives the wasm code using postMessage from the main thread, so we
don't need our instantiateWasm, either.